### PR TITLE
Update README

### DIFF
--- a/doc/README
+++ b/doc/README
@@ -16,7 +16,7 @@ Intro
 Stealth is a free open source project derived from NovaCoin, with
 the goal of providing a long-term energy-efficient scrypt-based crypto-currency.
 Built on the foundation of Bitcoin and NovaCoin, innovations such as proof-of-stake
-help further advance the field of crypto-currency.
+help to further advance the field of crypto-currency.
 
 Setup
 -----


### PR DESCRIPTION
The phrase "help further advance" should be replaced with "help to further advance", as it is more grammatically correct.